### PR TITLE
Show CSS Styling in Documentation

### DIFF
--- a/docs/_pages/ome-bhatkhande-english.md
+++ b/docs/_pages/ome-bhatkhande-english.md
@@ -293,24 +293,24 @@ For writing a full composition as shown above, a table is required, for example:
 
 with additional styling provided by:
 
-```scss
+```css
 table.composition {
   border: none;
+}
 
-  td {
-    width: 25%;
-    border: none;
-    border-right: 1px solid black;
-  }
+table.composition td {
+  width: 25%;
+  border: none;
+  border-right: 1px solid black;
+}
 
-  td:last-child {
-    border-right: none;
-  }
+table.composition td:last-child {
+  border-right: none;
+}
 
-  &.bhatkhande-english td > code {
-    white-space: pre;
-    font-family: 'ome_bhatkhande_english';
-  }
+table.composition.bhatkhande-english td > code {
+  white-space: pre;
+  font-family: 'ome_bhatkhande_english';
 }
 ```
 

--- a/docs/_pages/ome-bhatkhande-hindi.md
+++ b/docs/_pages/ome-bhatkhande-hindi.md
@@ -293,24 +293,24 @@ For writing a full composition as shown above, a table is required, for example:
 
 with additional styling provided by:
 
-```scss
+```css
 table.composition {
   border: none;
+}
 
-  td {
-    width: 25%;
-    border: none;
-    border-right: 1px solid black;
-  }
+table.composition td {
+  width: 25%;
+  border: none;
+  border-right: 1px solid black;
+}
 
-  td:last-child {
-    border-right: none;
-  }
+table.composition td:last-child {
+  border-right: none;
+}
 
-  &.bhatkhande-hindi td > code {
-    white-space: pre;
-    font-family: 'ome_bhatkhande_hindi';
-  }
+table.composition.bhatkhande-hindi td > code {
+  white-space: pre;
+  font-family: 'ome_bhatkhande_hindi';
 }
 ```
 

--- a/docs/_pages/ome-bhatkhande-punjabi.md
+++ b/docs/_pages/ome-bhatkhande-punjabi.md
@@ -291,24 +291,24 @@ For writing a full composition as shown above, a table is required, for example:
 
 with additional styling provided by:
 
-```scss
+```css
 table.composition {
   border: none;
+}
 
-  td {
-    width: 25%;
-    border: none;
-    border-right: 1px solid black;
-  }
+table.composition td {
+  width: 25%;
+  border: none;
+  border-right: 1px solid black;
+}
 
-  td:last-child {
-    border-right: none;
-  }
+table.composition td:last-child {
+  border-right: none;
+}
 
-  &.bhatkhande-punjabi td > code {
-    white-space: pre;
-    font-family: 'ome_bhatkhande_punjabi';
-  }
+table.composition.bhatkhande-punjabi td > code {
+  white-space: pre;
+  font-family: 'ome_bhatkhande_punjabi';
 }
 ```
 


### PR DESCRIPTION
Previously we showed SCSS styling in the docs, but this was confusing to users as it was not explicitly specified, and is not as well known as plain CSS.

This will be better.

Closes #35 